### PR TITLE
CLINIC-112-115: Corregir el editar y eliminar una cita.

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '8.0.x'   
+          dotnet-version: '9.0.x'   
 
       - name: Restore dependencies
         run: dotnet restore

--- a/README.md
+++ b/README.md
@@ -11,6 +11,25 @@ A folder called `Clinica` is used to organize the code, inspect logs, and access
 
 ---
 
+## 🔧 Prerequisitos
+
+Antes de compilar o ejecutar el backend asegúrate de tener instalado el SDK de .NET 9 y el runtime de ASP.NET Core 9.0:
+
+- `dotnet --list-sdks` debe mostrar `9.x`
+- `dotnet --list-runtimes` debe incluir `Microsoft.AspNetCore.App 9.x`
+
+Según tu sistema operativo puedes instalarlos con:
+
+- **Ubuntu/Debian**: `sudo apt-get update && sudo apt-get install -y dotnet-sdk-9.0 aspnetcore-runtime-9.0`
+- **Fedora/RHEL/CentOS**: `sudo dnf install dotnet-sdk-9.0 aspnetcore-runtime-9.0`
+- **Arch/Manjaro**: `sudo pacman -S dotnet-sdk aspnet-runtime`
+- **Windows (PowerShell admin)**: `winget install Microsoft.DotNet.SDK.9`
+- **macOS (Homebrew)**: `brew install --cask dotnet-sdk`
+
+Después de instalarlos, reinicia la terminal y valida nuevamente con `dotnet --info`.
+
+---
+
 ## 📁 Configuration Files
 
 ### 🐳 Dockerfile

--- a/src/Clinica.Tests/Clinica.Tests.csproj
+++ b/src/Clinica.Tests/Clinica.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/src/Clinica/Clinica.csproj
+++ b/src/Clinica/Clinica.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="3.7.304.11" />
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.14" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.7">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
@@ -19,7 +19,7 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.11.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Clinica/Clinica.csproj
+++ b/src/Clinica/Clinica.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="3.7.304.11" />
     <PackageReference Include="DotNetEnv" Version="3.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.14" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.7">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
@@ -19,7 +19,7 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.11.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Clinica/Controllers/AppointmentsController.cs
+++ b/src/Clinica/Controllers/AppointmentsController.cs
@@ -45,10 +45,7 @@ public class AppointmentsController : ControllerBase
                 })
                 .ToListAsync();
 
-            if (result.Count > 0)
-                return Ok(result);
-            else
-                return NotFound("No hay citas registradas.");
+            return Ok(result);
         }
         catch (Exception ex)
         {
@@ -88,10 +85,7 @@ public class AppointmentsController : ControllerBase
                 })
                 .ToListAsync();
 
-            if (result.Count > 0)
-                return Ok(result);
-            else
-                return NotFound("No hay citas para el día de hoy.");
+            return Ok(result);
         }
         catch (Exception ex)
         {
@@ -197,6 +191,7 @@ public class AppointmentsController : ControllerBase
             var appointment = await _context.Appointments
                 .Include(a => a.Diagnoses)
                 .Include(a => a.Treatments)
+                    .ThenInclude(t => t.Recipes)
                 .FirstOrDefaultAsync(a => a.Id == id);
 
             if (appointment == null)
@@ -209,6 +204,14 @@ public class AppointmentsController : ControllerBase
 
             if (appointment.Treatments.Any())
             {
+                foreach (var treatment in appointment.Treatments)
+                {
+                    if (treatment.Recipes.Any())
+                    {
+                        _context.Recipes.RemoveRange(treatment.Recipes);
+                    }
+                }
+
                 _context.Treatments.RemoveRange(appointment.Treatments);
             }
 

--- a/src/Clinica/Controllers/RecipesController.cs
+++ b/src/Clinica/Controllers/RecipesController.cs
@@ -25,7 +25,7 @@ public class RecipesController : ControllerBase
         Recipe newRecipe = new Recipe
         {
             TreatmentId = recipe.TreatmentId,
-            Prescription = recipe.Prescription,
+            Prescription = recipe.Prescription ?? string.Empty,
             CreatedAt = DateTime.Now,
         };
 
@@ -34,7 +34,7 @@ public class RecipesController : ControllerBase
         recipesSet.Add(newRecipe);
         await _context.SaveChangesAsync();
 
-        RecipeDTO response = new RecipeDTO { Id = newRecipe.Id, TreatmentId = newRecipe.TreatmentId, Prescription = newRecipe.Prescription };
+        RecipeDTO response = new RecipeDTO { Id = newRecipe.Id, TreatmentId = newRecipe.TreatmentId, Prescription = newRecipe.Prescription ?? string.Empty };
         return CreatedAtAction(nameof(GetRecipeById), new { id = newRecipe.Id }, response);
     }
 
@@ -53,7 +53,7 @@ public class RecipesController : ControllerBase
         {
             Id = recipe.Id,
             TreatmentId = recipe.TreatmentId,
-            Prescription = recipe.Prescription,
+            Prescription = recipe.Prescription ?? string.Empty,
         };
 
 

--- a/src/Clinica/Models/EntityFramework/Treatment.cs
+++ b/src/Clinica/Models/EntityFramework/Treatment.cs
@@ -25,7 +25,7 @@ public partial class Treatment
     public DateTime? UpdatedAt { get; set; }
 
     [Column("status")]
-    public string Status { get; set; }
+    public string Status { get; set; } = string.Empty;
 
     public virtual Appointment Appointment { get; set; } = null!;
 

--- a/src/Clinica/Models/ExamDTO.cs
+++ b/src/Clinica/Models/ExamDTO.cs
@@ -5,8 +5,8 @@ public class ExamDTO
     public int Id { get; set; }
     public int PatientId { get; set; }
     public int ExamId { get; set; }
-    public string ResultText { get; set; }
-    public string FileUrl { get; set; }
+    public string ResultText { get; set; } = string.Empty;
+    public string FileUrl { get; set; } = string.Empty;
 }
 
 

--- a/src/Clinica/Models/PatientExamRequestDTO.cs
+++ b/src/Clinica/Models/PatientExamRequestDTO.cs
@@ -13,6 +13,6 @@ namespace Clinica.Models
         public string? ResultText { get; set; }
 
         [Required]
-        public IFormFile File { get; set; }
+        public required IFormFile File { get; set; } = default!;
     }
 }

--- a/src/Clinica/Models/UpdateAppointmentDto.cs
+++ b/src/Clinica/Models/UpdateAppointmentDto.cs
@@ -1,0 +1,51 @@
+using System.Text.Json.Serialization;
+
+namespace Clinica.Models;
+
+/// <summary>
+/// DTO para actualizar parcialmente una cita médica.
+/// </summary>
+public class UpdateAppointmentDto
+{
+    /// <summary>
+    /// Identificador del paciente asociado a la cita.
+    /// </summary>
+    [JsonPropertyName("patientId")]
+    public int? PatientId { get; set; }
+
+    /// <summary>
+    /// Identificador del doctor asignado a la cita.
+    /// </summary>
+    [JsonPropertyName("doctorId")]
+    public int? DoctorId { get; set; }
+
+    /// <summary>
+    /// Nueva fecha y hora de la cita.
+    /// </summary>
+    [JsonPropertyName("appointmentDate")]
+    public DateTime? AppointmentDate { get; set; }
+
+    /// <summary>
+    /// Alias para aceptar "date" como campo desde el frontend.
+    /// </summary>
+    [JsonPropertyName("date")]
+    public DateTime? Date { get; set; }
+
+    /// <summary>
+    /// Valor textual del estado (acepta nombres de enum o alias).
+    /// </summary>
+    [JsonPropertyName("status")]
+    public string? Status { get; set; }
+
+    /// <summary>
+    /// Motivo de la cita.
+    /// </summary>
+    [JsonPropertyName("reason")]
+    public string? Reason { get; set; }
+
+    /// <summary>
+    /// Alias para aceptar "notes" como campo desde el frontend.
+    /// </summary>
+    [JsonPropertyName("notes")]
+    public string? Notes { get; set; }
+}

--- a/src/Clinica/Models/UpdateStatusDTO.cs
+++ b/src/Clinica/Models/UpdateStatusDTO.cs
@@ -1,7 +1,0 @@
-namespace Clinica.Models;
-
-public class UpdateStatusDTO
-{
-    public AppointmentStatus Status { get; set; }
-
-}

--- a/tests/UnitTets/AppointmentsControllerTests.cs
+++ b/tests/UnitTets/AppointmentsControllerTests.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Clinica.Controllers;
+using Clinica.Models;
+using Clinica.Models.EntityFramework;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using TUnit;
+using TUnit.Assertions;
+
+namespace UnitTests.Controllers;
+
+public class AppointmentsControllerTests : IAsyncDisposable
+{
+    private readonly ApplicationDbContext _context;
+    private readonly AppointmentsController _controller;
+    private int _appointmentId;
+    private int _patientId;
+    private int _doctorId;
+
+    public AppointmentsControllerTests()
+    {
+        var options = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        _context = new ApplicationDbContext(options);
+        SeedDataAsync().GetAwaiter().GetResult();
+        _controller = new AppointmentsController(_context);
+    }
+
+    [Test]
+    public async Task UpdateAppointment_WithAliasStatusAndNotes_ShouldPersistChanges()
+    {
+        var dto = new UpdateAppointmentDto
+        {
+            Status = "general.confirmed",
+            Notes = "Paciente reagendado",
+            Date = DateTime.SpecifyKind(DateTime.UtcNow.AddDays(1), DateTimeKind.Unspecified)
+        };
+
+        var result = await _controller.UpdateAppointment(_appointmentId, dto);
+
+        var okResult = result as OkObjectResult;
+        await Assert.That(okResult).IsNotNull();
+
+        var updated = await _context.Appointments.FirstAsync(a => a.Id == _appointmentId);
+        await Assert.That(updated.Status).IsEqualTo(AppointmentStatus.Confirmado);
+        await Assert.That(updated.Reason).IsEqualTo("Paciente reagendado");
+        await Assert.That(updated.AppointmentDate.Date).IsEqualTo(dto.Date!.Value.Date);
+    }
+
+    [Test]
+    public async Task UpdateAppointment_WithMissingPatient_ShouldReturnNotFound()
+    {
+        var dto = new UpdateAppointmentDto
+        {
+            PatientId = 9999
+        };
+
+        var result = await _controller.UpdateAppointment(_appointmentId, dto);
+
+        var notFound = result as NotFoundObjectResult;
+        await Assert.That(notFound).IsNotNull();
+        await Assert.That(notFound!.Value).IsEqualTo("No se encontró el paciente con ID 9999.");
+    }
+
+    [Test]
+    public async Task DeleteAppointment_ShouldRemoveDependencies()
+    {
+        var medicine = new Medicine
+        {
+            Name = "Ibuprofeno",
+            Type = "Tableta",
+            CreatedAt = DateTime.UtcNow
+        };
+        await _context.Medicines.AddAsync(medicine);
+        await _context.SaveChangesAsync();
+
+        var diagnosis = new Diagnosis
+        {
+            AppointmentId = _appointmentId,
+            Description = "Dolor de cabeza",
+            CreatedAt = DateTime.UtcNow
+        };
+
+        var treatment = new Treatment
+        {
+            AppointmentId = _appointmentId,
+            MedicineId = medicine.Id,
+            Dosis = "1 cada 8h",
+            Duration = "3 días",
+            Status = "Activo",
+            CreatedAt = DateTime.UtcNow
+        };
+
+        await _context.Diagnoses.AddAsync(diagnosis);
+        await _context.Treatments.AddAsync(treatment);
+        await _context.SaveChangesAsync();
+
+        var recipe = new Recipe
+        {
+            TreatmentId = treatment.Id,
+            Prescription = "Usar según indicado",
+            CreatedAt = DateTime.UtcNow
+        };
+
+        await _context.Recipes.AddAsync(recipe);
+        await _context.SaveChangesAsync();
+
+        var result = await _controller.DeleteAppointment(_appointmentId);
+
+        var okResult = result as OkObjectResult;
+        await Assert.That(okResult).IsNotNull();
+
+        await Assert.That(await _context.Appointments.AnyAsync(a => a.Id == _appointmentId)).IsFalse();
+        await Assert.That(await _context.Diagnoses.AnyAsync(d => d.AppointmentId == _appointmentId)).IsFalse();
+        await Assert.That(await _context.Treatments.AnyAsync(t => t.AppointmentId == _appointmentId)).IsFalse();
+        await Assert.That(await _context.Recipes.AnyAsync(r => r.TreatmentId == treatment.Id)).IsFalse();
+    }
+
+    private async Task SeedDataAsync()
+    {
+        var patient = new Patient
+        {
+            Name = "Juan",
+            LastName = "Pérez",
+            Birthdate = DateOnly.FromDateTime(DateTime.UtcNow.AddYears(-30)),
+            Gender = "M",
+            Address = "Centro",
+            BloodTypeId = 1,
+            PatientTypeId = 1,
+            CreatedAt = DateTime.UtcNow
+        };
+
+        var doctor = new User
+        {
+            FirstName = "Laura",
+            LastName = "García",
+            Email = "laura@example.com",
+            PasswordHash = "hash",
+            RoleId = 1,
+            CreatedAt = DateTime.UtcNow
+        };
+
+        await _context.Patients.AddAsync(patient);
+        await _context.Users.AddAsync(doctor);
+        await _context.SaveChangesAsync();
+
+        _patientId = patient.Id;
+        _doctorId = doctor.Id;
+
+        var appointment = new Appointment
+        {
+            PatientId = _patientId,
+            DoctorId = _doctorId,
+            AppointmentDate = DateTime.SpecifyKind(DateTime.UtcNow, DateTimeKind.Unspecified),
+            Status = AppointmentStatus.Pendiente,
+            Reason = "Chequeo",
+            CreatedAt = DateTime.SpecifyKind(DateTime.UtcNow, DateTimeKind.Unspecified)
+        };
+
+        await _context.Appointments.AddAsync(appointment);
+        await _context.SaveChangesAsync();
+
+        _appointmentId = appointment.Id;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _context.DisposeAsync();
+    }
+}

--- a/tests/UnitTets/UnitTests.csproj
+++ b/tests/UnitTets/UnitTests.csproj
@@ -4,13 +4,13 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.7" />
-    <PackageReference Include="TUnit" Version="0.24.0" />
+    <PackageReference Include="TUnit" Version="0.56.50" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Contexto
Se requería del lado de frontend poder editar y eliminar las citas de una forma exitosa, lo cual el backend estaba dando problemas, este PR solventa esta situación.

## Modificaciones

1. `.github/workflows/ci-backend.yml` Solamente se actualiza la versión de dotnet.
2. `README.md` UN PROBLEMA era que teniamos 2 VERSIONES (a saber porqué) la versión 8 y 9, actualmente TODO el proyecto usa la 9, asi que el readme lo aclara., los mismo sucede en estos archivos

- `src/Clinica.Tests/Clinica.Tests.csproj`
- `src/Clinica/Clinica.csproj`
- `tests/UnitTets/UnitTests.csproj`

3. `src/Clinica/Controllers/PatientsController.cs`: Se corrigen warnings, igual que en los siguientes archivos:

- `src/Clinica/Controllers/RecipesController.cs`
- `src/Clinica/Models/EntityFramework/Treatment.cs`
- `src/Clinica/Models/ExamDTO.cs`
- `src/Clinica/Models/PatientExamRequestDTO.cs`

4. `tests/UnitTets/AppointmentsControllerTests.cs`Actualización de los endpoints necesarios para el frontend
5. `src/Clinica/Models/UpdateAppointmentDto.cs` Actualización del DTO a usar.
6. `src/Clinica/Models/UpdateStatusDTO.cs` eliminar DTO obsoleto

## Pruebas
Tests unitarios en: `tests/UnitTets/AppointmentsControllerTests.cs`