### PR TITLE
[feature] aceptar cors para el server

### DIFF
--- a/src/Clinica/Program.cs
+++ b/src/Clinica/Program.cs
@@ -45,7 +45,7 @@ public class Program
         {
             options.AddPolicy("AllowFrontend", policy =>
             {
-                policy.WithOrigins("http://localhost:5173")
+                policy.WithOrigins("http://localhost:5173", "http://172.176.96.39")
                     .AllowAnyHeader()
                     .AllowAnyMethod();
             });


### PR DESCRIPTION
## 🔧 Fix: Configurar CORS para permitir acceso desde IP pública

### Problema
La aplicación desplegada en Azure bloqueaba las peticiones del frontend debido a política de CORS restrictiva que solo permitía `localhost:5173`.

### Solución
- Agregada IP pública del servidor (`http://172.176.96.39`) a los orígenes permitidos en CORS
- Mantiene configuración de desarrollo con `localhost:5173`

### Cambios en `Program.cs`
```csharp
// Antes
policy.WithOrigins("http://localhost:5173")

// Después
policy.WithOrigins("http://localhost:5173", "http://172.176.96.39")
```

## Resultado

✅ Frontend puede comunicarse con backend en producción
✅ Autenticación y endpoints API funcionando correctamente
✅ Compatible con ambiente de desarrollo local