### PR TITLE
[fix] estandar para tener /api en BE

### DIFF
--- a/src/Clinica/Program.cs
+++ b/src/Clinica/Program.cs
@@ -78,7 +78,7 @@ public class Program
 
         builder.Services.Configure<FormOptions>(o =>
         {
-            o.MultipartBodyLengthLimit = 25_000_000; 
+            o.MultipartBodyLengthLimit = 25_000_000;
         });
 
         var app = builder.Build();

--- a/src/Clinica/Program.cs
+++ b/src/Clinica/Program.cs
@@ -15,7 +15,6 @@ public class Program
 {
     public static async Task Main(string[] args)
     {
-        // Detectar ruta real del .env (está en backend-v1/.env)
         var envPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".env"));
         Console.WriteLine($"[BOOT] .env path => {envPath} Exists? {File.Exists(envPath)}");
         if (File.Exists(envPath)) Env.Load(envPath);
@@ -79,12 +78,11 @@ public class Program
 
         builder.Services.Configure<FormOptions>(o =>
         {
-            o.MultipartBodyLengthLimit = 25_000_000; // 25 MB
+            o.MultipartBodyLengthLimit = 25_000_000; 
         });
 
         var app = builder.Build();
 
-        // Esperar a que la base de datos esté lista y aplicar migraciones (solo una vez, sin ciclo)
         using (var scope = app.Services.CreateScope())
         {
             var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
@@ -103,7 +101,9 @@ public class Program
         app.UseAuthorization();
 
         app.MapGet("/ping", () => Results.Json(new { message = "pong" }));
-        app.MapControllers();
+
+        var apiGroup = app.MapGroup("/api");
+        apiGroup.MapControllers();
 
         Console.WriteLine("CFG Cloudflare AccountId => " + (builder.Configuration["Cloudflare:AccountId"] ?? "NULL"));
 


### PR DESCRIPTION
## 🔧 Refactor: Agregar prefijo `/api` a todas las rutas del backend

### Problema
Las rutas del backend estaban definidas sin un prefijo estándar, lo que dificultaba:
- Configuración del proxy reverso en Nginx
- Distinción clara entre endpoints de API y rutas del frontend
- Escalabilidad y mantenimiento del código

### Solución
- Implementado `MapGroup("/api")` en `Program.cs` para agregar el prefijo `/api` a todos los controladores
- Todas las rutas del backend ahora siguen el estándar RESTful

### Cambios
**Antes:**
- `/appointments`
- `/patients`
- `/auth/login`

**Después:**
- `/api/appointments`
- `/api/patients`
- `/api/auth/login`

### Beneficios
- ✅ Configuración de Nginx simplificada (un solo `location /api`)
- ✅ Separación clara entre rutas de API y frontend
- ✅ Facilita implementación de versionado futuro (`/api/v2`)
- ✅ Sigue convenciones estándar de diseño de APIs REST

### Archivos modificados
- `src/Clinica/Program.cs`

### Testing
- Backend desplegado y funcionando correctamente
- Todas las rutas accesibles bajo el prefijo `/api`